### PR TITLE
Buscador global de bandas con resultados en overlay

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -1302,3 +1302,78 @@ div#final {
         width: 100% !important;
     }
 }
+
+/* ================================================
+   Search Bar — Responsive Overrides
+   ================================================ */
+
+/* Desktop: hide the mobile control wrapper (buttons are inside it) */
+@media (min-width: 1024px) {
+    #mobile-bar-controls {
+        display: none;
+    }
+}
+
+/* Mobile: side-by-side MENÚ + 🔍 buttons */
+@media (max-width: 1023px) {
+    /* Shift language flag left so it doesn't overlap the search button (54px wide) */
+    div#banderes {
+        right: 62px !important;
+    }
+    #mobile-bar-controls {
+        display: flex;
+        align-items: stretch;
+        width: 100%;
+    }
+
+    /* Let the menu button grow, but not force full width */
+    #mobile-bar-controls .mobile-menu-toggle {
+        flex: 1;
+        width: auto !important;
+    }
+
+    /* Search icon button */
+    #searchMobileToggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #800000;
+        border: none;
+        border-left: 1px solid #400000;
+        color: #fff;
+        font-size: 20px;
+        width: 54px;
+        min-width: 54px;
+        cursor: pointer;
+        padding: 0;
+    }
+
+    #searchMobileToggle.active {
+        background: #600;
+    }
+
+    /* Search bar hidden by default; shown when JS adds .search-open */
+    #search-bar {
+        display: none !important;
+        width: 100% !important;
+        margin: 0 !important;
+        padding: 8px 10px !important;
+        box-sizing: border-box;
+    }
+
+    #search-bar.search-open {
+        display: flex !important;
+    }
+
+    /* Prevent iOS zoom on focus */
+    #search-input {
+        font-size: 16px !important;
+    }
+
+    /* Overlay stretches full width on mobile */
+    #search-overlay {
+        left: 0 !important;
+        width: 100% !important;
+        max-height: 65vh;
+    }
+}

--- a/css/search.css
+++ b/css/search.css
@@ -1,0 +1,165 @@
+/* ============================================================
+   Search Bar + Overlay — SatanArise.com
+   ============================================================ */
+
+/* ----- Search bar (below #barramanu, always visible on desktop) ----- */
+#search-bar {
+    clear: left;
+    width: 980px;
+    margin: 0 10px 6px 10px;
+    box-sizing: border-box;
+    padding: 5px 10px;
+    background: #1a0000;
+    border-bottom: 2px solid #600;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+#search-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: #ddd;
+    font-family: "Copperplate Gothic Light", Verdana, Arial, Helvetica, sans-serif;
+    font-size: 13px;
+    outline: none;
+    padding: 3px 0;
+    min-width: 0;
+}
+
+#search-input::placeholder {
+    color: #666;
+    font-style: italic;
+}
+
+/* Clear button — hidden until input has text (JS adds .has-text to #search-bar) */
+#search-clear {
+    display: none;
+    background: none;
+    border: none;
+    color: #888;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 2px;
+    flex-shrink: 0;
+}
+
+#search-clear:hover {
+    color: #fff;
+}
+
+#search-bar.has-text #search-clear {
+    display: block;
+}
+
+/* Mobile search toggle: hidden on desktop, shown on mobile via responsive.css */
+#searchMobileToggle {
+    display: none;
+}
+
+/* ----- Overlay (fixed, positioned by JS) ----- */
+#search-overlay {
+    display: none;
+    position: fixed;
+    z-index: 9999;
+    background: #0d0000;
+    border: 1px solid #600;
+    border-top: none;
+    max-height: 480px;
+    overflow-y: auto;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.85);
+}
+
+#search-overlay-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 12px;
+    background: #600;
+    color: #fff;
+    font-family: "Copperplate Gothic Light", Verdana, Arial, Helvetica, sans-serif;
+    font-size: 11px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    position: sticky;
+    top: 0;
+}
+
+#search-close {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    padding: 0 2px;
+    opacity: 0.8;
+}
+
+#search-close:hover {
+    opacity: 1;
+    color: #faa;
+}
+
+#search-results {
+    padding: 10px 14px 14px;
+}
+
+.search-section {
+    margin-bottom: 14px;
+}
+
+.search-section:last-child {
+    margin-bottom: 0;
+}
+
+.search-section h3 {
+    color: #cc2200;
+    font-family: "Copperplate Gothic Light", Verdana, Arial, Helvetica, sans-serif;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    margin: 0 0 6px 0;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #330000;
+}
+
+.search-section ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.search-section li {
+    border-bottom: 1px solid #1a0000;
+}
+
+.search-section li:last-child {
+    border-bottom: none;
+}
+
+.search-section a {
+    display: block;
+    padding: 5px 4px;
+    color: #bbb;
+    text-decoration: none;
+    font-size: 12px;
+    font-family: Verdana, Arial, Helvetica, sans-serif;
+    line-height: 1.4;
+}
+
+.search-section a:hover {
+    color: #fff;
+    background: #2a0000;
+}
+
+.search-noresults {
+    color: #777;
+    font-size: 12px;
+    font-family: Verdana, Arial, Helvetica, sans-serif;
+    padding: 6px 0;
+    margin: 0;
+}

--- a/js/search.js
+++ b/js/search.js
@@ -1,0 +1,145 @@
+/**
+ * Global band search — SatanArise.com
+ */
+(function () {
+    'use strict';
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initSearch);
+    } else {
+        initSearch();
+    }
+
+    function initSearch() {
+        var input        = document.getElementById('search-input');
+        var overlay      = document.getElementById('search-overlay');
+        var resultsDiv   = document.getElementById('search-results');
+        var closeBtn     = document.getElementById('search-close');
+        var clearBtn     = document.getElementById('search-clear');
+        var mobileToggle = document.getElementById('searchMobileToggle');
+        var searchBar    = document.getElementById('search-bar');
+
+        if (!input || !overlay || !searchBar) return;
+
+        var timer;
+
+        /* ---- input handler with debounce ---- */
+        input.addEventListener('input', function () {
+            clearTimeout(timer);
+            var q = input.value.trim();
+            searchBar.classList.toggle('has-text', input.value.length > 0);
+            if (q.length < 3) { closeOverlay(); return; }
+            timer = setTimeout(function () { doSearch(q); }, 350);
+        });
+
+        /* ---- overlay close button ---- */
+        if (closeBtn) {
+            closeBtn.addEventListener('click', closeOverlay);
+        }
+
+        /* ---- clear button: wipes input and closes overlay ---- */
+        if (clearBtn) {
+            clearBtn.addEventListener('click', function () {
+                input.value = '';
+                searchBar.classList.remove('has-text');
+                closeOverlay();
+                input.focus();
+            });
+        }
+
+        /* ---- click outside closes overlay ---- */
+        document.addEventListener('click', function (e) {
+            if (overlay.style.display !== 'block') return;
+            if (!overlay.contains(e.target) && !searchBar.contains(e.target)) {
+                closeOverlay();
+            }
+        });
+
+        /* ---- mobile search toggle ---- */
+        if (mobileToggle) {
+            mobileToggle.addEventListener('click', function (e) {
+                e.stopPropagation();
+                if (searchBar.classList.contains('search-open')) {
+                    searchBar.classList.remove('search-open');
+                    mobileToggle.classList.remove('active');
+                    closeOverlay();
+                } else {
+                    searchBar.classList.add('search-open');
+                    mobileToggle.classList.add('active');
+                    setTimeout(function () { input.focus(); }, 50);
+                }
+            });
+        }
+
+        /* ---- reposition overlay on resize ---- */
+        window.addEventListener('resize', function () {
+            if (overlay.style.display === 'block') positionOverlay();
+        });
+
+        /* ---- core functions ---- */
+
+        function doSearch(q) {
+            var ln = getLang();
+            fetch('search_ajax.php?q=' + encodeURIComponent(q) + '&ln=' + ln)
+                .then(function (r) { return r.json(); })
+                .then(function (data) { renderResults(data.results, q); })
+                .catch(function () { /* silent — network error */ });
+        }
+
+        function getLang() {
+            var m = window.location.search.match(/[?&]ln=([^&]+)/);
+            return (m && m[1] === 'CAT') ? 'CAT' : 'ES';
+        }
+
+        function renderResults(results, q) {
+            var sections = {
+                noticias:    'Noticias',
+                conciertos:  'Conciertos',
+                criticas:    'Críticas',
+                entrevistas: 'Entrevistas'
+            };
+            var html  = '';
+            var total = 0;
+
+            Object.keys(sections).forEach(function (key) {
+                var items = results[key];
+                if (!items || items.length === 0) return;
+                total += items.length;
+                html += '<div class="search-section"><h3>' + sections[key] + '</h3><ul>';
+                items.forEach(function (item) {
+                    html += '<li><a href="' + esc(item.url) + '">' + esc(item.title) + '</a></li>';
+                });
+                html += '</ul></div>';
+            });
+
+            if (total === 0) {
+                html = '<p class="search-noresults">No se encontraron resultados para &ldquo;<strong>'
+                     + esc(q) + '</strong>&rdquo;</p>';
+            }
+
+            resultsDiv.innerHTML = html;
+            positionOverlay();
+            overlay.style.display = 'block';
+        }
+
+        function positionOverlay() {
+            var rect = searchBar.getBoundingClientRect();
+            overlay.style.top   = rect.bottom + 'px';
+            overlay.style.left  = rect.left   + 'px';
+            overlay.style.width = rect.width  + 'px';
+        }
+
+        function closeOverlay() {
+            overlay.style.display = 'none';
+            resultsDiv.innerHTML  = '';
+        }
+
+        function esc(s) {
+            return String(s)
+                .replace(/&/g,  '&amp;')
+                .replace(/</g,  '&lt;')
+                .replace(/>/g,  '&gt;')
+                .replace(/"/g,  '&quot;');
+        }
+    }
+})();

--- a/search_ajax.php
+++ b/search_ajax.php
@@ -1,0 +1,144 @@
+<?php
+require_once('sources/ob_bbdd.php');
+
+header('Content-Type: application/json; charset=utf-8');
+header('X-Content-Type-Options: nosniff');
+
+$q  = isset($_GET['q'])  ? trim($_GET['q'])  : '';
+$ln = (isset($_GET['ln']) && $_GET['ln'] === 'CAT') ? 'CAT' : 'ES';
+
+$empty = ['noticias' => [], 'conciertos' => [], 'criticas' => [], 'entrevistas' => []];
+
+if (mb_strlen($q) < 3) {
+    echo json_encode(['results' => $empty]);
+    exit;
+}
+
+$basedades = new ob_bbdd;
+$basedades->conectar();
+
+if ($basedades->error_conexio) {
+    http_response_code(503);
+    echo json_encode(['error' => 'db']);
+    exit;
+}
+
+$bd   = $basedades->bd;
+/* NOTE: Do NOT call set_charset('utf8') here.
+   The DB columns are declared latin1 but the bytes stored are already UTF-8
+   (legacy data inserted without proper charset declaration).
+   Asking MySQL to convert would double-encode and produce garbage (Ã³ etc.).
+   Returning the raw bytes lets json_encode treat them as valid UTF-8. */
+$term = $bd->real_escape_string($q);
+
+$results = $empty;
+
+/* Decode HTML entities stored literally in old DB records (e.g. &quot; -> ") */
+function clean(string $s): string {
+    return html_entity_decode($s, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+}
+
+/* ---- Noticias ---- */
+$idioma       = ($ln === 'CAT') ? 'CAT' : 'ES';
+$sec_noticias = ($ln === 'CAT') ? 'noticies' : 'noticias';
+$r = $bd->query(
+    "SELECT news.idNews, newscontent.Title, news.dateIn
+     FROM news
+     INNER JOIN newscontent ON news.idNews = newscontent.idNews
+     WHERE newscontent.Idioma = '$idioma'
+       AND newscontent.Title LIKE '%$term%'
+     ORDER BY news.dateIn DESC
+     LIMIT 5"
+);
+if ($r && $r->num_rows > 0) {
+    while ($row = $r->fetch_assoc()) {
+        $title = clean($row['Title']);
+        $fecha = !empty($row['dateIn']) ? date('d/m/Y', strtotime($row['dateIn'])) : '';
+        $results['noticias'][] = [
+            'title' => $title . ($fecha ? ' - ' . $fecha : ''),
+            'url'   => 'index.php?ln=' . $ln
+                       . '&sec=' . $sec_noticias
+                       . '&id=' . (int) $row['idNews']
+                       . '&noticia=' . urlencode($title),
+        ];
+    }
+}
+
+/* ---- Conciertos ---- */
+$sec_conciertos = ($ln === 'CAT') ? 'concerts' : 'conciertos';
+/* No DISTINCT: fetch dateConcert + localitat per row, deduplicate in PHP keeping earliest date */
+$r = $bd->query(
+    "SELECT concerts.idGig, concerts.Nom, concertsgrups.Grup,
+            concertsdata.dateConcert, concertsdata.localitat
+     FROM concerts
+     INNER JOIN concertsdata  ON concerts.idGig          = concertsdata.idGig
+     INNER JOIN concertsgrups ON concertsdata.idConcert  = concertsgrups.idConcert
+     WHERE concertsgrups.Grup LIKE '%$term%'
+        OR concerts.Nom       LIKE '%$term%'
+     ORDER BY concerts.dateIn DESC, concertsdata.dateConcert ASC
+     LIMIT 20"
+);
+if ($r && $r->num_rows > 0) {
+    $seen = [];
+    while ($row = $r->fetch_assoc()) {
+        $id = (int) $row['idGig'];
+        if (isset($seen[$id])) continue;
+        $seen[$id] = true;
+        $name  = clean(!empty($row['Nom']) ? $row['Nom'] : $row['Grup']);
+        $fecha = !empty($row['dateConcert']) ? date('d/m/Y', strtotime($row['dateConcert'])) : '';
+        $city  = clean($row['localitat']);
+        $extra = implode(' - ', array_filter([$fecha, $city]));
+        $results['conciertos'][] = [
+            'title' => $name . ($extra ? ' - ' . $extra : ''),
+            'url'   => 'index.php?ln=' . $ln
+                       . '&sec=' . $sec_conciertos
+                       . '&type=entrada&id=' . $id,
+        ];
+        if (count($results['conciertos']) === 5) break;
+    }
+}
+
+/* ---- Críticas / Reviews ---- */
+$sec_criticas = ($ln === 'CAT') ? 'critiques' : 'criticas';
+$r = $bd->query(
+    "SELECT reviews.link, reviews.banda, reviews.disc, reviews.any
+     FROM reviews
+     WHERE reviews.banda LIKE '%$term%'
+       AND release_date <= NOW()
+     ORDER BY reviews.release_date DESC
+     LIMIT 5"
+);
+if ($r && $r->num_rows > 0) {
+    while ($row = $r->fetch_assoc()) {
+        $results['criticas'][] = [
+            'title' => clean($row['banda']) . ' – ' . clean($row['disc']) . ' (' . $row['any'] . ')',
+            'url'   => 'index.php?ln=' . $ln . '&sec=' . $sec_criticas . '&' . $row['link'],
+        ];
+    }
+}
+
+/* ---- Entrevistas ---- */
+$sec_entrevistas  = ($ln === 'CAT') ? 'entrevistes'  : 'entrevistas';
+$idioma_filter    = ($ln === 'CAT') ? "idioma = 'CAT' OR idioma = 'BOTH'" : "idioma = 'ES' OR idioma = 'BOTH'";
+$titol_field      = ($ln === 'CAT') ? 'titol_cat' : 'titol_es';
+$r = $bd->query(
+    "SELECT entrevistes.link, entrevistes.banda, entrevistes.$titol_field AS titol
+     FROM entrevistes
+     WHERE entrevistes.banda LIKE '%$term%'
+       AND ($idioma_filter)
+     ORDER BY entrevistes.data DESC
+     LIMIT 5"
+);
+if ($r && $r->num_rows > 0) {
+    while ($row = $r->fetch_assoc()) {
+        $titol = !empty($row['titol']) ? ' — ' . clean($row['titol']) : '';
+        $results['entrevistas'][] = [
+            'title' => clean($row['banda']) . $titol,
+            'url'   => 'index.php?ln=' . $ln . '&sec=' . $sec_entrevistas . '&' . $row['link'],
+        ];
+    }
+}
+
+$basedades->desconectar();
+
+echo json_encode(['results' => $results], JSON_UNESCAPED_UNICODE);

--- a/sources/ob_page.php
+++ b/sources/ob_page.php
@@ -111,11 +111,13 @@ class ob_page
 			'<link type="text/css" rel="stylesheet" media="all" href="css/index.css" />',
 			'<link type="text/css" rel="stylesheet" media="all" href="css/iframe.css" />',
 			'<link type="text/css" rel="stylesheet" media="all" href="css/responsive.css?v=2" />',
+			'<link type="text/css" rel="stylesheet" media="all" href="css/search.css" />',
 		];
 		$this->words =
 			'Metal, reviews, críticas, entrevistas, noticias, power, viking, death, heavy, trash, black, gothic, gotico, progresive, progresivo';
 		$this->scripts = [
-			'<script type="text/javascript" src="js/responsive-menu.js"></script>'
+			'<script type="text/javascript" src="js/responsive-menu.js"></script>',
+			'<script type="text/javascript" src="js/search.js"></script>',
 		];
 		$this->punter = 1;
 		$this->quantitat = 36;

--- a/templates/top.php
+++ b/templates/top.php
@@ -416,10 +416,13 @@ $page->print_heads();
 		</div>
 
 		<div id="barramanu"> <!-- -------------------------------------------------- M E N U --------------------------------------------------- -->
-			<!-- Mobile Menu Toggle Button -->
-			<button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation menu">
-				<?php echo 'MENÚ'; ?>
-			</button>
+			<!-- Mobile controls: hamburger + search icon -->
+			<div id="mobile-bar-controls">
+				<button class="mobile-menu-toggle" id="mobileMenuToggle" aria-label="Toggle navigation menu">
+					<?php echo 'MENÚ'; ?>
+				</button>
+				<button id="searchMobileToggle" aria-label="Buscar banda">&#128269;</button>
+			</div>
 
 			<div id="menu">
 				<?php
@@ -643,6 +646,24 @@ $page->print_heads();
 
 			</div>
 		</div>
+
+		<!-- ---- SEARCH BAR ---- -->
+		<div id="search-bar">
+			<input type="text" id="search-input"
+				placeholder="<?php echo ($page->leng === 'CAT') ? '🔍 escriu la banda que vols buscar ...' : '🔍 escribe la banda que quieres buscar ...'; ?>"
+				autocomplete="off" spellcheck="false" />
+			<button id="search-clear" aria-label="Borrar búsqueda">&#10005;</button>
+		</div>
+
+		<!-- ---- SEARCH OVERLAY (positioned by JS) ---- -->
+		<div id="search-overlay">
+			<div id="search-overlay-header">
+				<span><?php echo ($page->leng === 'CAT') ? 'Resultats de la cerca' : 'Resultados de búsqueda'; ?></span>
+				<button id="search-close" aria-label="Cerrar">&#10005;</button>
+			</div>
+			<div id="search-results"></div>
+		</div>
+
 		<div id="col_left"> <!-- Columan de discografies -->
 			<?php
 			require('templates/banners/col_left.php');


### PR DESCRIPTION
Añade barra de búsqueda bajo el menú principal que busca en noticias, conciertos (con fecha y ciudad), críticas y entrevistas mediante AJAX. Incluye botón de borrado, overlay con cierre, soporte CAT/ES y adaptación móvil con icono 🔍 junto al hamburger. Encoding corregido para BBDDs con bytes UTF-8 en columnas latin1.